### PR TITLE
Install APCu stable version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN pecl install apcu-beta && echo extension=apcu.so > $PHP_INI_DIR/conf.d/apcu.ini
+RUN pecl install apcu && echo extension=apcu.so > $PHP_INI_DIR/conf.d/apcu.ini
 
 # Apache configuration
 RUN a2enmod rewrite


### PR DESCRIPTION
APCu is now shipped on two channels, beta and stable.

The beta version is for PHP 7, the stable version PHP 5.3+.
